### PR TITLE
Patch - Report page: updating some i18n strings, removing bg-light class

### DIFF
--- a/examples/audit-report-fr.html
+++ b/examples/audit-report-fr.html
@@ -25,12 +25,12 @@ layout: no-container
 			<section class="oag-brdr oag-rds p-4 mb-4 small">
 				<h2 class="wb-inv">Métadonnées du rapport</h2>
 				<dl class="mb-0">
-					<dt class="mt-2 mb-1">Date de dépôt</dt>
+					<dt class="mt-2 mb-1">Date de publication</dt>
 					<dd class="mb-2"><time datetime="2025-06-05">6 mai 2025</time></dd>
-					<dt class="mt-4 mb-1">Entités auditées</dt>
+					<dt class="mt-4 mb-1">Entité(s) auditée(s)</dt>
 					<dd class="mb-2">Entité 1</dd>
 					<dd class="mb-2">Entité avec un très long nom 2</dd>
-					<dt class="mt-4 mb-1">Sujets</dt>
+					<dt class="mt-4 mb-1">Sujet(s)</dt>
 					<dd class="mb-2">Sujet 1</dd>
 					<dd class="mb-2">Sujet avec un très très très très très long nom 2</dd>
 					<dd class="mb-2">Sujet avec un très long nom 3</dd>
@@ -49,7 +49,7 @@ layout: no-container
 				<span>Ressources multimédias <br>(273&nbsp;<abbr title="Kilo-octet">KO</abbr>)</span>
 			</a>
 			<section>
-				<h2 class="h6">Audits connexes</h2>
+				<h2 class="h6">Audit(s) connexe(s)</h2>
 				<ul class="mb-4">
 					<li><a href="#">Audit avec un très long nom 1</a></li>
 					<li><a href="#">Audit avec un encore plus long nom 2</a></li>
@@ -83,7 +83,7 @@ layout: no-container
 			</div>
 		</div>
 	</div>
-	<div class="my-4 bg-light px-4 py-5">
+	<div class="my-4 px-4 py-5">
 		<h2 class="mt-0">Points forts de la preuve</h2>
 		<div class="wb-tabs vertical">
 			<div class="tabpanels">
@@ -122,7 +122,7 @@ layout: no-container
 		</div>
 	</div>
 	<section class="mt-5">
-		<h2>Articles connexes</h2>
+		<h2>Rapport(s) connexe(s)</h2>
 		<div class="row wb-eqht-grd hght-inhrt">
 			<div class="col-xs-12 col-sm-6 col-lg-4">
 				<article class="oag-card oag-heading-as-body bg-light h-100">

--- a/examples/audit-report.html
+++ b/examples/audit-report.html
@@ -25,15 +25,15 @@ layout: no-container
 			<section class="oag-brdr oag-rds p-4 mb-4 small">
 				<h2 class="wb-inv">Report metadata</h2>
 				<dl class="mb-0">
-					<dt class="mt-2 mb-1">Tabling date</dt>
+					<dt class="mt-2 mb-1">Release date</dt>
 					<dd class="mb-2"><time datetime="2025-06-05">May 6, 2025</time></dd>
 
-					<dt class="mt-4 mb-1">Audited entities</dt>
+					<dt class="mt-4 mb-1">Audited entitie(s)</dt>
 					<dd class="mb-2">Entity 1</dd>
 					<dd class="mb-2">Entity 2 with long long long long long long name 1</dd>
 					<dd class="mb-2">Entity 3</dd>
 
-					<dt class="mt-4 mb-1">Topics</dt>
+					<dt class="mt-4 mb-1">Topic(s)</dt>
 					<dd class="mb-2">Topic 1</dd>
 					<dd class="mb-2">Topic 2 with long long long long long long long name </dd>
 					<dd class="mb-2">Topic 3</dd>
@@ -53,7 +53,7 @@ layout: no-container
 				<span>Media Assets <br>(273&nbsp;<abbr title="KiloByte">KB</abbr>)</span>
 			</a>
 			<section>
-				<h2 class="h6">Related Audits</h2>
+				<h2 class="h6">Related Audit(s)</h2>
 				<ul class="mb-4">
 					<li><a href="#">Related audit 1</a></li>
 					<li><a href="#">Related audit with very long name 2</a></li>
@@ -87,7 +87,7 @@ layout: no-container
 			</div>
 		</div>
 	</div>
-	<div class="my-4 bg-light px-4 py-5">
+	<div class="my-4 px-4 py-5">
 		<h2 class="mt-0">Exhibit Highlights</h2>
 		<div class="wb-tabs vertical">
 			<div class="tabpanels">
@@ -126,7 +126,7 @@ layout: no-container
 		</div>
 	</div>
 	<section class="mt-5">
-		<h2>Related Articles</h2>
+		<h2>Related Article(s)</h2>
 		<div class="row wb-eqht-grd hght-inhrt">
 			<div class="col-xs-12 col-sm-6 col-lg-4">
 				<article class="oag-card oag-heading-as-body bg-light h-100">


### PR DESCRIPTION
EN
Tabling date --> Release date
Audited entities --> Audited entitie(s)
Topics --> Topic(s)
(No need for the ":" in the current AEM template as these act as headings)

Related Audits --> Related Audit(s)

Removed class "bg-light" (Exhibit Highlights section)

Related Articles --> Related report(s)

FR
Date de dépôt --> Date de publication
Entités auditées --> Entités auditée(s)
Sujets --> Sujet(s)
(No need for the ":" in the current AEM template as these act as headings)

Audits connexes --> Audits connexe(s)

Removed class "bg-light" (Visuels choisis section)

Articles connexes --> Rapport(s) connexe(s)