### PR TITLE
Update colour values to be compliant with WCAG 2.1 AA Contrast.

### DIFF
--- a/assets/oag.css
+++ b/assets/oag.css
@@ -15,9 +15,9 @@
 
 	/* OAG Report type label colors */
 	--oag-report-01: #852828;
-	--oag-report-02: #977E42;
+	--oag-report-02: #8C7337;
 	--oag-report-03: #005e59;
-	--oag-report-04: #6c8a5a;
+	--oag-report-04: #617f4f;
 
 	/* OAG Neutral colors */
 	--oag-neutral-01: #ebd9ab;
@@ -736,7 +736,7 @@
 		&[data-report-type='special-examinations'], 
 		&[data-report-type='other-products'] {
 			background: var(--oag-report-02);
-			color: #333;
+			color: #fff;
 		}
 
 		~ time {
@@ -989,8 +989,8 @@
 		
 		.form-group > label, fieldset > legend {
 			/* Label styling for filter fields */
-			color: var(--oag-default-border-color);
-			font-weight: 100;
+			color: var(--oag-footer);
+			font-weight: 300;
 			font-size: .85em;
 		}
 

--- a/examples/content-fr.html
+++ b/examples/content-fr.html
@@ -137,7 +137,9 @@ layout: default
 <p><span class="label label-default" data-report-type="auditor-general-reports">Libellé Auditor general reports</span></p>
 <p><span class="label label-default" data-report-type="commissioner-of-the-environment-and-sustainable-development-reports">Libellé Rapports du commissaire à l'environnement et au développement durable</span></p>
 <p><span class="label label-default" data-report-type="northern-legislative-assembly-reports">Libellé Rapports des assemblées législatives du Nord</span></p>
-<p><span class="label label-default" data-report-type="special-examinations-of-crown-corporations">Libellé Rapports d’examen spécial des sociétés d’État</span></p>
+<p><span class="label label-default" data-report-type="special-examinations">Examens spéciaux</span></p>
+<p><span class="label label-default" data-report-type="commentaries-on-financial-audits">Commentaires sur les audits financiers</span></p>
+<p><span class="label label-default" data-report-type="other-products">Autres produits</span></p>
 
 <details class="mt-3">
 	<summary>Code</summary>
@@ -146,7 +148,9 @@ layout: default
 &lt;p>&lt;span class="label label-default" data-report-type="auditor-general-reports">Libellé Rapports du vérificateur général&lt;/span>&lt;/p>
 &lt;p>&lt;span class="label label-default" data-report-type="commissioner-of-the-environment-and-sustainable-development-reports">Libellé Rapports du commissaire à l'environnement et au développement durable&lt;/span>&lt;/p>
 &lt;p>&lt;span class="label label-default" data-report-type="northern-legislative-assembly-reports">Libellé Rapports des assemblées législatives du Nord&lt;/span>&lt;/p>
-&lt;p>&lt;span class="label label-default" data-report-type="special-examinations-of-crown-corporations">Libellé Rapports d’examen spécial des sociétés d’État&lt;/span>&lt;/p></code></pre>
+&lt;p>&lt;span class="label label-default" data-report-type="special-examinations">Examens spéciaux&lt;/span>&lt;/p></code></pre>
+&lt;p>&lt;span class="label label-default" data-report-type="commentaries-on-financial-audits">Commentaires sur les audits financiers&lt;/span>&lt;/p></code></pre>
+&lt;p>&lt;span class="label label-default" data-report-type="other-products>Autres produits&lt;/span>&lt;/p></code></pre>
 </details>
 
 <h2 id="tabbed-interface">Interface à onglets - variante verticale</h2>

--- a/examples/content.html
+++ b/examples/content.html
@@ -481,7 +481,9 @@ layout: default
 <p><span class="label label-default" data-report-type="auditor-general-reports">Auditor general reports label</span></p>
 <p><span class="label label-default" data-report-type="commissioner-of-the-environment-and-sustainable-development-reports">Commissioner of the environment and sustainable development reports label</span></p>
 <p><span class="label label-default" data-report-type="northern-legislative-assembly-reports">Northern legislative assembly reports label</span></p>
-<p><span class="label label-default" data-report-type="special-examinations-of-crown-corporations">Special examinations of crown corporations</span></p>
+<p><span class="label label-default" data-report-type="special-examinations">Special examinations</span></p>
+<p><span class="label label-default" data-report-type="commentaries-on-financial-audits">Commentaries on financial audits</span></p>
+<p><span class="label label-default" data-report-type="other-products">Other products</span></p>
 <details class="mt-3">
 	<summary>Code</summary>
 	<pre><code>&lt;p>&lt;span class="label label-default">Default label&lt;/span>&lt;/p>
@@ -489,7 +491,9 @@ layout: default
 &lt;p>&lt;span class="label label-default" data-report-type="auditor-general-reports">Auditor general reports label&lt;/span>&lt;/p>
 &lt;p>&lt;span class="label label-default" data-report-type="commissioner-of-the-environment-and-sustainable-development-reports">Commissioner of the environment and sustainable development reports label&lt;/span>&lt;/p>
 &lt;p>&lt;span class="label label-default" data-report-type="northern-legislative-assembly-reports">Northern legislative assembly reports label&lt;/span>&lt;/p>
-&lt;p>&lt;span class="label label-default" data-report-type="special-examinations-of-crown-corporations">Special examinations of crown corporations&lt;/span>&lt;/p>
+&lt;p>&lt;span class="label label-default" data-report-type="special-examinations">Special examinations&lt;/span>&lt;/p>
+&lt;p>&lt;span class="label label-default" data-report-type="commentaries-on-financial-audits">Commentaries on financial audits&lt;/span>&lt;/p>
+&lt;p>&lt;span class="label label-default" data-report-type="other-products">Other products&lt;/span>&lt;/p>
 </code></pre>
 </details>
 


### PR DESCRIPTION
Updates styling of a few UI elements to ensure they meet WCAG 2.1 AA contrast requirements. @Garneauma 

**Changes**
- Updated --oag-report-02 from #977E42 to #8C7337.
- Updated --oag-report-04 from #6C8A5A to #617F4F.
- Updated special-examination and other-products tag text colour from #333 to #fff.
- Updated the legend class styling used for filter field labels:
- Changed colour from --oag-default-border-color to --oag-footer.
- Increased font weight from 100 to 300.